### PR TITLE
Update IO.R

### DIFF
--- a/pkg/R/IO.R
+++ b/pkg/R/IO.R
@@ -328,10 +328,11 @@ make.input.format =
                           names(family.columns), 
                           function(fam) 
                             paste(
-                              base64encode(fam), 
-                              sapply(family.columns[[fam]], base64encode),
-                              sep = ":", 
-                              collapse = " ")))),
+							sapply(1:length(family.columns[[fam]]),
+							function(w) 
+							base64encode(
+							paste(fam,":",family.columns[[fam]][w],sep = "",collapse = "")
+							)),sep="",collapse=" ")))),
                   libjars = system.file(package = "rmr2", "hadoopy_hbase.jar")))})}
     if(is.null(streaming.format) && mode == "binary") 
       streaming.format = "org.apache.hadoop.streaming.AutoInputFormat"


### PR DESCRIPTION
By supplying code to the Revolution Analytics team, I agree to assign copyright of that code to Revolution Analytics Inc., on the condition that it releases that code under the Apache 2.0 license.

just updated lines 325-336 for correcting base64 encoding. Although "caTools" package needed to be updated to encode column family correctly.
