### PR TITLE
Shebang not honored on Debian 6

### DIFF
--- a/hadoopy_hbase/java/build_linux.sh
+++ b/hadoopy_hbase/java/build_linux.sh
@@ -15,6 +15,10 @@
 #limitations under the License.
 
 
+if [ ! "$BASH_VERSION" ] ; then
+    exec /bin/bash "$0" "$@"
+fi
+
 ARGS=$(getopt -o h -l "hadoop_path:,hbase_path:" -n "build_linux.sh" -- "$@");
 eval set -- "$ARGS";
 


### PR DESCRIPTION
Adds compatibility to Debian 6 squeeze. Prevents running this script by "SH" instead of "BASH" during installation of "rmr2" on Debian 6. I agree to assign copyright of that code to Revolution Analytics Inc., on the condition that it releases that code under the Apache 2.0 license.
